### PR TITLE
Fix #13 recursive import of signs

### DIFF
--- a/lib/vimade/fader.py
+++ b/lib/vimade/fader.py
@@ -7,7 +7,6 @@ import vim
 import math
 import time
 from vimade import highlighter
-from vimade import signs
 from vimade import colors
 from vimade.buf_state import BufState
 from vimade.win_state import WinState


### PR DESCRIPTION
The module signs was imported in bridge.py and fader.py. fader was also
imported in signs.py leading to a recursive import of signs and the
python error "ImportError: cannot import name signs". This lead to the
plugin not starting correctly at vim startup and a load of vim error
messages.

The signs module is already imported in bridge.py and fader is not
imported in any other modules except for signs itself which makes the
import of signs in fader.py unnecessary.
Therefore, the import in fader.py was simply removed.