### PR TITLE
Support neovim's multiple sign columns

### DIFF
--- a/autoload/vimade.vim
+++ b/autoload/vimade.vim
@@ -597,6 +597,11 @@ function! vimade#StopTimer()
   endif
 endfunction
 
+function! vimade#CreateHighlights()
+    let l:signcolcolors = vimade#GetHi(hlID("SignColumn"))
+    execute 'hi VimadeEmptyFillSignColumn guifg=' . l:signcolcolors[1] . ' guibg=' . l:signcolcolors[1]
+endfunction
+
 function! vimade#Init()
   let g:vimade_init = 1
   call vimade#CreateGlobals()
@@ -604,6 +609,7 @@ function! vimade#Init()
   call vimade#GetDefaults()
   call vimade#ExtendState()
   call vimade#UpdateEvents()
+  call vimade#CreateHighlights()
 
   let g:vimade_last = extend({}, g:vimade)
 


### PR DESCRIPTION
Hi,

Some time ago I've reported #54 with `signcolumn` setting in neovim that I'm using. This PR fixes the main issue, which is displaying doubled signs and one of them is not dimmed - really burns my eyes often. The solution is not perfect, but IMO is good enough.

![vimade-multiple-sign-columns-fix](https://user-images.githubusercontent.com/4434640/110251609-8db6ac80-7f81-11eb-9c7c-7585b9c2e9ed.png)

Neovim has a special signcolumn setting value *auto:x* where x is the
number of displayed signs in one line. Current implementation of dimming
the signs is to add copy of existing signs with higher priority to be on
top of covered sign. When this setting was on, the original sign was not
covered, by the extra sign. Instead the two signs were normally
displayed...

The solution is to fill the sign column with empty signs (fg, and bg
same as the signcolumn bg). The number of inserted empty signs is the
number possible sings minus number of original signs in line, ie. The
signcolumn setting is `auto:3`, at line x editor displays 1 sign. The
number of empty signs is 3-1=2. So, in total we add 1 sign to replace
original and two empty to fill the sign column. This way the original
sign is covered.

Note: this solution is not perfect, but fixes what this plugin should
do, it doesn't burn eyes of a user. As we create empty signs they will
always fill the signcolumn, and in some cases it will "extend" the
signcolumn when there is no signs to display.

This commit is combination of following squashed commits:

* Fill sign cols with multiple vimade signs
* Use special sign with fg=bg as placeholder
* Get number of sign columns from vim setting
* Eval signcolumn on fade_wins