### PR TITLE
Fixes invalid escape sequence when using python 3.9

### DIFF
--- a/lib/vimade/signs.py
+++ b/lib/vimade/signs.py
@@ -9,7 +9,7 @@ SIGN_CACHE = {}
 PLACES = []
 SIGN_IDS_UNUSED = []
 def parseParts(line):
-  parts = re.split('[\s\t]+', line)
+  parts = re.split(r'[\s\t]+', line)
   item = {}
   for part in parts:
     split = part.split('=')


### PR DESCRIPTION
See https://bugs.python.org/issue27364

Fixes this error when using python 3.9:

```
Error detected while processing VimEnter Autocommands for "*"..script .../vimade/autoload/vimade.vim[649]..function vimade#Init[20]..vimade#CheckWindows:
line    7:
.../vimade/lib/vimade/signs.py:12: SyntaxWarning: invalid escape sequence '\s'

Error detected while processing VimEnter Autocommands for "*"..script ...d/vimade/autoload/vimade.vim[649]..function vimade#Init[20]..vimade#CheckWindows:
  parts = re.split('[\s\t]+', line)
```