### PR TITLE
Feature/ignore bufnames from config

### DIFF
--- a/autoload/vimade.vim
+++ b/autoload/vimade.vim
@@ -214,6 +214,12 @@ function! vimade#GetDefaults()
 
     let g:vimade_defaults.enabletreesitter = 0
 
+    ""@setting vimade.ignorebuffers
+    "A list of buffer names or patterns to ignore. Buffers matching these will not be faded.
+    "Example: ['neo-tree', 'NvimTree', '*.log']
+
+    let g:vimade_defaults.ignorebuffers = []
+
     let g:vimade_defaults_keys = keys(g:vimade_defaults)
     if exists('g:vimade_detect_term_colors')
       let g:vimade.detecttermcolors = g:vimade_detect_term_colors

--- a/autoload/vimade.vim
+++ b/autoload/vimade.vim
@@ -458,9 +458,10 @@ function! vimade#CheckWindows()
     return
   endif
   if g:vimade_running && g:vimade_paused == 0 && getcmdwintype() == ''
+    " echo "Debug: ignorebuffers = " . string(g:vimade.ignorebuffers)
     exec g:vimade_py_cmd join([
         \ "from vimade import bridge",
-        \ "bridge.update({'activeBuffer': str(vim.current.buffer.number), 'activeTab': '".tabpagenr()."', 'activeWindow': '".win_getid(winnr())."'})",
+        \ "bridge.update({'activeBuffer': str(vim.current.buffer.number), 'activeTab': '".tabpagenr()."', 'activeWindow': '".win_getid(winnr())."', 'ignorebuffers': vim.eval('string(g:vimade.ignorebuffers)')})",
     \ ], "\n")
   endif
 endfunction

--- a/lib/vimade/bridge.py
+++ b/lib/vimade/bridge.py
@@ -3,6 +3,7 @@ from vimade import signs
 from vimade import fader
 from vimade import highlighter
 from vimade import global_state as GLOBALS
+import ast
 
 def getInfo():
   return GLOBALS.getInfo()
@@ -29,4 +30,12 @@ def recalculate():
   highlighter.recalculate()
 
 def update(nextState = None):
+  global GLOBALS
+  # print(f"Debug: Received state in Python: {nextState}")
+  
+  if 'ignorebuffers' in nextState:
+      try:
+          GLOBALS.ignorebuffers = ast.literal_eval(nextState['ignorebuffers'])
+      except:
+          GLOBALS.ignorebuffers = [nextState['ignorebuffers']]
   fader.update(nextState)

--- a/lib/vimade/fader.py
+++ b/lib/vimade/fader.py
@@ -102,6 +102,9 @@ def update(nextState = None):
     tabnr = str(window.tabpage.number)
     if activeTab != tabnr:
       continue
+    buffer_name = window.buffer.name
+    if should_ignore_buffer(buffer_name):
+      continue
     (winid, diff, wrap, buftype, win_disabled, buf_disabled, vimade_fade_active, scrollbind, win_syntax, buf_syntax, tabstop) = util.eval_and_return('[win_getid('+winnr+'), gettabwinvar('+tabnr+','+winnr+',"&diff"), gettabwinvar('+tabnr+','+winnr+',"&wrap"), gettabwinvar('+tabnr+','+winnr+',"&buftype"), gettabwinvar('+tabnr+','+winnr+',"vimade_disabled"), getbufvar('+bufnr+', "vimade_disabled"),  g:vimade_fade_active, gettabwinvar('+tabnr+','+winnr+',"&scrollbind"), gettabwinvar('+tabnr+','+winnr+',"current_syntax"), gettabwinvar('+tabnr+','+winnr+',"&syntax"), gettabwinvar('+tabnr+','+winnr+',"&tabstop")]')
     syntax = win_syntax if win_syntax else buf_syntax
     floating = util.eval_and_return('nvim_win_get_config('+str(winid)+')') if HAS_NVIM_WIN_GET_CONFIG else False

--- a/lib/vimade/fader.py
+++ b/lib/vimade/fader.py
@@ -6,6 +6,7 @@ if (sys.version_info > (3, 0)):
 import vim
 import math
 import time
+import fnmatch
 from vimade import util
 from vimade import highlighter
 from vimade import signs
@@ -28,6 +29,10 @@ changedWin = False
 buffers = {}
 activeWindow = util.eval_and_return('win_getid('+str(vim.current.window.number)+')')
 activeBuffer = str(vim.current.buffer.number)
+
+def should_ignore_buffer(buffer_name):
+    ignore_patterns = GLOBALS.ignorebuffers
+    return any(fnmatch.fnmatch(buffer_name, pattern) for pattern in ignore_patterns)
 
 
 

--- a/lib/vimade/fader.py
+++ b/lib/vimade/fader.py
@@ -32,7 +32,7 @@ activeBuffer = str(vim.current.buffer.number)
 
 def should_ignore_buffer(buffer_name):
     ignore_patterns = GLOBALS.ignorebuffers
-    return any(fnmatch.fnmatch(buffer_name, pattern) for pattern in ignore_patterns)
+    return any(pattern in buffer_name or fnmatch.fnmatch(buffer_name, pattern) for pattern in ignore_patterns)
 
 
 

--- a/lib/vimade/fader.py
+++ b/lib/vimade/fader.py
@@ -1,4 +1,5 @@
 import sys
+import fnmatch
 IS_V3 = False
 if (sys.version_info > (3, 0)):
     IS_V3 = True
@@ -31,11 +32,25 @@ activeWindow = util.eval_and_return('win_getid('+str(vim.current.window.number)+
 activeBuffer = str(vim.current.buffer.number)
 
 def should_ignore_buffer(buffer_name):
-    ignore_patterns = GLOBALS.ignorebuffers
-    return any(pattern in buffer_name or fnmatch.fnmatch(buffer_name, pattern) for pattern in ignore_patterns)
+  global GLOBALS
 
+  # print(f"Debug: Checking buffer: {buffer_name}")
+  # print(f"Debug: GLOBALS.ignorebuffers = {GLOBALS.ignorebuffers}")
 
+  ignore_patterns = GLOBALS.ignorebuffers
+  
+  if not isinstance(ignore_patterns, list):
+      ignore_patterns = [ignore_patterns]
+  
+  buffer_name = buffer_name.lower()  # Make case-insensitive
+  
+  result = any(
+      str(pattern).lower() in buffer_name or fnmatch.fnmatch(buffer_name, str(pattern).lower())
+      for pattern in ignore_patterns
+  )
 
+  # print(f"Debug: Should ignore {buffer_name}: {result}")
+  return result
 
 
 def update(nextState = None):
@@ -201,7 +216,7 @@ def update(nextState = None):
     elif not state.faded and not hasActiveBuffer:
       fade[winid] = state
 
-    if 'coc-explorer' in state.name or 'NERD' in state.name:
+    if 'coc-explorer' in state.name or 'NERD' in state.name or 'neo-tree' in state.name:
       state.is_explorer = True
     if 'vim-minimap' in state.name or '-MINIMAP-' in state.name:
       state.is_minimap = True

--- a/lib/vimade/global_state.py
+++ b/lib/vimade/global_state.py
@@ -64,6 +64,8 @@ ENABLE_SIGNS = 8
 DISABLE_SIGNS = 16
 BASEGROUPS = 32
 
+ignorebuffers = []
+
 def getInfo():
   global_vars = vars(GLOBALS)
   result = {}


### PR DESCRIPTION
This PR will enable specifying a list of buffers to ignore. This is the config I'm using with the Lazy plugin manager.

```lua
---@type LazySpec
return {
  {
    dir = "~/Code/vimade",
    config = function()
      vim.g.vimade = {
        enabletreesitter = 1,
        fadelevel = 0.7,
        enablesigns = 1,
        ignorebuffers = { "neo-tree" },
      }
    end,
  },
}
```

99% of this code was written with the help of Claude 3.5 Sonnet, but it took many hours of prompting and "discussing" issues with the chat UI, logging things out, lots of testing, etc. to come to a working solution. I'm a Ruby dev, so Python is somewhat familiar, but I've never worked on a full blown project/codebase, nor written an entire neovim plugin 😅 so I'm not sure how good/bad this code is. But it does work! (on my machine... 🙈😇)

One thing that has my code smell nose tickling is the `literal_eval` code on line 464 of the `autoload/vimade.vim` file

```python
ast.literal_eval(nextState['ignorebuffers'])
```

It's _probably_ fine, since generally a plugin installer owns their configuration and wouldn't put values in the value for `ignorebuffers` that would be malicious. And again, I'm no python expert, but I think this a small vector for bad actors to suggest people put things in there that could cause harm? 

One possible change would be switching to a comma delimited string that we could likely more safely turn into an array of values in python versus having to do the `literal_eval` of the lua table. 🤷 Open to thoughts! 