### PR TITLE
fix(python-renderer): IndexError on multi-byte buffers

### DIFF
--- a/lib/vimade/state/namespace.py
+++ b/lib/vimade/state/namespace.py
@@ -302,7 +302,7 @@ class Namespace:
         s_col -= adjust_start
         s_col = max(s_col, 1)
         m_col = min(m_col, text_ln)
-        to_eval.append((row-1, s_col - 1, m_col -1, buf[r]))
+        to_eval.append((row-1, s_col - 1, m_col -1, text))
 
     coords = shared_state.get(coords_key)
     contents_changed = None


### PR DESCRIPTION
  ## Summary
  Fix `IndexError` in `process_syn` when fading buffers with multi-byte characters
  (Japanese, devicons, emoji) on the Python 3 / `IS_V3` path. The error fires within
  seconds of switching windows and, after 3 occurrences, auto-disables vimade.

  <img width="677" height="84" alt="01-indexerror-tick" src="https://github.com/user-attachments/assets/61e98b94-92e8-41fd-a14b-b16d2805066a" />
  <img width="869" height="109" alt="02-indexerror-deferred-tick" src="https://github.com/user-attachments/assets/dbfffc83-2cae-4928-af0f-9675695981e6" />


  ## Root cause
  On `IS_V3`, `text` and `text_ln` are computed in UTF-8 **bytes** (namespace.py:278-279)
  and `m_col` is clamped to `text_ln`. But the row entry pushed to `to_eval` was `buf[r]` — a Python `str` whose `len()` counts **characters**. Downstream, `process_syn` sizes the
  color grid by character count and indexes into it with `m_col - 1` (byte index). Any byte
   index past the character count → `IndexError`.

  Visible symptom of the same mismatch — the tail of each multi-byte line stays un-faded:

  <img width="550" height="93" alt="03-nerdtree-tail-not-faded" src="https://github.com/user-attachments/assets/295022aa-0958-4301-ad00-33d2ca7d33b8" />

  ## Fix
  `lib/vimade/state/namespace.py:305`: store `text` (the bytes already computed two lines above) instead of `buf[r]`. 
  Grid sizing and column indices now share the same unit. ASCII buffers are unaffected (byte length == character length).

  ## Repro
  Vim 9.x + Python 3, open a buffer with Japanese / devicons, `:vsplit`, switch windows.

  ---

  Thanks for maintaining vimade — happy to iterate on this patch if a different approach is preferred.